### PR TITLE
Added parameter to choose the static directory from package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,21 @@ yarn add parcel-plugin-static-files-copy --dev
 2. Fill it with your static files
 3. Run build - and that's all!
 
+### Customization options
+
+> The plugin allows you to name the forder whose contents should be present in the build output directory.
+
+Customize the folder from where static resources need to be copied using the `staticPath` parameter in package.json file.
+
+```json
+// package.json
+
+{
+	...
+    "staticPath": "public"
+}
+```
+
 ## Contribute
 
 You're interested in contributing? Awesome! Fork, make change, commit and create pull request. I'll do my best to merge changes!

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-static-files-copy",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "ParcelJS plugin to copy static files from 'static/' dir to bundle directory.",
   "main": "index.js",
   "keywords": [


### PR DESCRIPTION
## Description
The path/folder name to the static directory can now be customizable from package.json - Issue #1 

## How Has This Been Tested?
**Testing environment:** Windows CLI
Validates whether the path exists before proceeding with file copy. Throws error otherwise.