### PR TITLE
Support new bundler api `getPackage`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,17 @@
 const fs = require("file-system");
 const path = require("path");
 
-module.exports = bundler => {
+module.exports = async bundler => {
     bundler.on("bundled", bundle => {
         let pkgFile;
         if (
+            bundler.mainAsset &&
+            bundler.mainAsset.getPackage
+        ) {
+            // for parcel-bundler version@<1.9
+            pkgFile = await bundler.mainAsset.getPackage();
+        }
+        else if (
             bundler.mainAsset &&
             bundler.mainAsset.package &&
             bundler.mainAsset.package.pkgfile


### PR DESCRIPTION
Fix for deprecation warning as reported in #5.

This was edited via GitHub's editor, so I haven't really tested this. :^) Hopefully parcel users have updated their node versions to support async functions.