### PR TITLE
Fix staticpath

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-static-files-copy",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "ParcelJS plugin to copy static files from 'static/' dir to bundle directory.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
After latest update, the staticPath could not be fetched from package.json file, as pkgFile was now a Promise.