### PR TITLE
Ensure copyFile is called even if filesize is the same

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ module.exports = bundler => {
                             const srcStat = fs.statSync(filepath);
                             if (destStat.size !== srcStat.size) { // Probably not the same, print a info about overwriting the file
                                 console.info(`Info: Static file '${filepath}' do already exist in '${bundleDir}'. Overwriting.`);
-                                fs.copyFile(filepath, dest);
                             }
+                            fs.copyFile(filepath, dest);
                         } else {
                             fs.copyFile(filepath, dest);
                         }


### PR DESCRIPTION
Currently, file size is used to infer whether a file has changed ([lines 33-36](https://github.com/elwin013/parcel-plugin-static-files-copy/blob/master/index.js#L33-L36)). 

## Issue
Files (especially data files) may have their contents changed, but still result in identical filesizes. E.g. JSON data could have GUIDs or certain integer values change, and bytes would remain the same.

## Fix
This PR moves the `fs.copyFile()` call out of the file size condition, to ensure it runs regardless of that outcome.

As a side note, would there be other comparisons to explore (e.g. file last modified timestamp?) that might result in a more definitive "has the file changed" check?
