### PR TITLE
Copy only specific files

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,23 @@ The following configures the plugin to copy all files in `public` to the build d
 }
 ```
 
+### Copying only specific files
+Setting the`matchGlob` property to `true`, will cause only desired files to be copied, helps when you need to deep-copy contents from directory, exampel:
+
+```json
+// package.json
+{
+	...
+    "staticFiles": {
+        "staticPath": "src",
+        "watcherGlob": "**/locales/*.+(txt|json)",
+        "matchGlob": true
+    }
+}
+```
+
+This above copy (and watch for changes) all files from `src/example/locales/`, that have the `json` or `txt` extension, into `dist/example/locales/`.
+
 ### Multiple Static Directories
 
 To copy more than one directory to the build directory, specify `staticPath` as an array. The following copies `public` and `vendor/public`:

--- a/index.js
+++ b/index.js
@@ -70,6 +70,10 @@ module.exports = bundler => {
             if (fs.existsSync(staticDir)) {
                 const copy = (filepath, relative, filename) => {
                     const dest = filepath.replace(staticDir, bundleDir);
+                    if (config.matchGlob && !minimatch(dest, config.watcherGlob || '**')) {
+                        return;
+                    }
+
                     if (!filename) {
                         fs.mkdir(filepath, dest);
                     } else {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "parcel-plugin-static-files-copy",
-  "version": "2.0.0",
+  "version": "2.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This PR adds the feature to only copy specific files, matching the watcher glob, helps if you want to copy from deeper paths, within the `staticPath`, without including everything in it.

Please add your comments, I'm happy to make changes. 