### PR TITLE
Fix nesting staticOutDirs

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,13 +110,13 @@ module.exports = bundler => {
             }
         };
 
-        let bundleDir = path.dirname(bundle.name || bundler.mainBundle.childBundles.values().next().value.name);
+        const bundleDir = path.dirname(bundle.name || bundler.mainBundle.childBundles.values().next().value.name);
         for (let dir of config.staticPath) {
-            if (dir.staticOutDir) {
-                bundleDir = path.join(bundleDir, dir.staticOutDir);
-            }
+            const copyTo = dir.staticOutDir
+                ? path.join(bundleDir, dir.staticOutDir)
+                : bundleDir;
 
-            copyDir(path.join(pkg.pkgdir, dir.staticPath), bundleDir);
+            copyDir(path.join(pkg.pkgdir, dir.staticPath), copyTo);
         }
 
         if (config.watcherGlob && bundler.watcher) {


### PR DESCRIPTION
Fixes a bug where a config like

```json
"staticFiles": {
    "staticPath": [
      {
        "staticPath": "src/assets/locales",
        "staticOutDir": "/locales"
      },
      {
        "staticPath": "src/assets/email",
        "staticOutDir": "/email"
      }
    ]
  },
```

would result in the following output:

```
- dist/
  - locales/
    - email/
```

i.e., in case of multiple `staticOutDir`s, any subsequent dirs get nested inside the previous one.