### PR TITLE
fix(exclude-glob): works for outputDirPatterns and multiple static paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,10 +74,10 @@ module.exports = bundler => {
 
         // recursive copy function
         let numWatches = 0;
-        const copyDir = (staticDir, bundleDir) => {
+        const copyDir = (staticDir, bundleDir, excludeGlob) => {
             if (fs.existsSync(staticDir)) {
                 const copy = (filepath, relative, filename) => {
-                    if (config.excludeGlob && config.excludeGlob.find(excludeGlob =>
+                    if (excludeGlob.find(excludeGlob =>
                         minimatch(filepath, path.join(staticDir, excludeGlob), config.globOptions)
                     )) {
                         return;
@@ -115,8 +115,9 @@ module.exports = bundler => {
             const copyTo = dir.staticOutDir
                 ? path.join(bundleDir, dir.staticOutDir)
                 : bundleDir;
-
-            copyDir(path.join(pkg.pkgdir, dir.staticPath), copyTo);
+            // merge global exclude glob with static path exclude glob
+            const excludeGlob = (config.excludeGlob || []).concat((dir.excludeGlob || [])); 
+            copyDir(path.join(pkg.pkgdir, dir.staticPath), copyTo, excludeGlob);
         }
 
         if (config.watcherGlob && bundler.watcher) {


### PR DESCRIPTION
When using the [Different source of static files based on output directory](https://github.com/elwin013/parcel-plugin-static-files-copy#different-source-of-static-files-based-on-output-directory) configuration, you could only use `excludeGlob` in the root of the config. 

This PR merges `excludeGlobs` defined in each item in the staticPath array with the "global" `excludeGlob`

```json
  "staticFiles": {
        "excludeGlob": [
            "path1/**"
        ],
        "staticPath": [
            {
                "outDirPattern": "**/dist/path1",
                "staticPath": "./src/path1-but-keep-path2"
            },
            {
                "outDirPattern": "**/dist/path2",
                "staticPath": "./src/exclude-path1-and-path2",
                "excludeGlob": [
                    "path2/**"
                ]
            }
        ]
    }
```