### PR TITLE
Made the fs function calls synchronous

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,17 +85,17 @@ module.exports = bundler => {
 
                     const dest = filepath.replace(staticDir, bundleDir);
                     if (!filename) {
-                        fs.mkdir(filepath, dest);
+                        fs.mkdirSync(filepath, dest);
                     } else {
                         if (fs.existsSync(dest)) {
                             const destStat = fs.statSync(dest);
                             const srcStat = fs.statSync(filepath);
                             if (destStat.mtime <= srcStat.mtime) { // File was modified - let's copy it and inform about overwriting.
                                 pmLog(3, `Static file '${filepath}' already exists in '${bundleDir}'. Overwriting.`);
-                                fs.copyFile(filepath, dest);
+                                fs.copyFileSync(filepath, dest);
                             }
                         } else {
-                            fs.copyFile(filepath, dest);
+                            fs.copyFileSync(filepath, dest);
                         }
                         // watch for changes?
                         if (config.watcherGlob && bundler.watcher && minimatch(filepath, config.watcherGlob, config.globOptions)) {


### PR DESCRIPTION
I ran into an issue that some (bigger) static files weren't copied before the next script got executed that uses some of these files.

After some I research I found out this library is using async filesystem functions without waiting for the promise to resolve. So when this script is finished you can't be sure all static files are copied.

When I applied these changes the problem was resolved. Would be nice if you can merge this and create a new release, then I can remove my fork again :wink: 