### PR TITLE
Exclude examples in npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+examples
+node_modules
+.vscode
+.idea


### PR DESCRIPTION
During tracing my node_modules size I found that the examples here are not excluded. I found it quite bit large compared to actual plugin code:

![image](https://user-images.githubusercontent.com/20214420/83670438-60595e80-a5fd-11ea-97fd-829a81260cc0.png)

This PR creates a separate ignore file to exclude examples for NPM. But if you bothered with separate ignore file it's okay anyway.